### PR TITLE
Add h1 heading to demons page

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,5 @@
 <div style="width:100%; display:block; float:left;">
+    <h1>angular datepocker</h1>
 
     <div class="wrap">
         <div style=" display:block; float:left;">


### PR DESCRIPTION
Add an h1 header "angular datepocker" to the demo page as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ad9bbe5-9f86-4d2d-94f1-c551955cc141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ad9bbe5-9f86-4d2d-94f1-c551955cc141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

