### PR TITLE
Debug release and npm publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,11 @@
         "@semantic-release/changelog": "^6.0.0",
         "@semantic-release/git": "^10.0.0",
         "@semantic-release/github": "^9.0.0",
+        "@semantic-release/npm": "^11.0.0",
+        "@semantic-release/release-notes-generator": "^12.0.0",
         "@types/node": "^20.0.0",
         "codecov.io": "^0.1.6",
+        "conventional-changelog-conventionalcommits": "^7.0.0",
         "cz-conventional-changelog": "^3.1.0",
         "ng-packagr": "^19.2.0",
         "semantic-release": "^22.0.0",
@@ -8089,6 +8092,19 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
       "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "semantic-release": "^22.0.0",
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/git": "^10.0.0",
-    "@semantic-release/github": "^9.0.0"
+    "@semantic-release/github": "^9.0.0",
+    "@semantic-release/npm": "^11.0.0",
+    "@semantic-release/release-notes-generator": "^12.0.0",
+    "conventional-changelog-conventionalcommits": "^7.0.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Add missing `semantic-release` dependencies to resolve `Cannot find module` errors during release analysis and enable proper CI/CD publishing.

---
<a href="https://cursor.com/background-agent?bcId=bc-a2bcadc2-1c2a-4ffd-a3e3-43532985c9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a2bcadc2-1c2a-4ffd-a3e3-43532985c9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

