### PR TITLE
Исправить отображение предыдущих дней в режиме одного месяца

### DIFF
--- a/projects/angular-datepicker2/src/lib/_service/calendar.service.ts
+++ b/projects/angular-datepicker2/src/lib/_service/calendar.service.ts
@@ -80,6 +80,8 @@ export class CalendarService {
       this.showPrevNextDaysInOneMonth = showPrevNextDaysInOneMonth;
       // Trigger calendar recalculation
       this.getShownMonths(this.shownDate);
+      // Notify components about the change
+      this.updateDate.next(new Date());
     }
   }
 
@@ -173,6 +175,8 @@ export class CalendarService {
 
     this.calendar = months;
     this.viewSelectorMode = "days";
+    // Notify components about the change
+    this.updateDate.next(new Date());
   }
 
   goPrev(firstDate: Date) {

--- a/projects/angular-datepicker2/src/lib/month-view/month-view.component.ts
+++ b/projects/angular-datepicker2/src/lib/month-view/month-view.component.ts
@@ -61,6 +61,13 @@ export class MonthViewComponent implements OnInit, OnDestroy {
       })
     );
 
+    // Subscribe to calendar updates to recalculate weeks when showPrevNextDaysInOneMonth changes
+    this.sub.add(
+      this.calendarService.updateDate.subscribe(() => {
+        this.recalculateWeeks();
+      })
+    );
+
     this.recalculateWeeks();
   }
 

--- a/projects/angular-datepicker2/src/lib/week-view/week-view.component.html
+++ b/projects/angular-datepicker2/src/lib/week-view/week-view.component.html
@@ -1,6 +1,6 @@
 <div *ngFor="let date of dates" class="f1">
-    <app-day-view *ngIf="date" [dayDirective]="getDayDirective(date)!" [date]="date"
+    <app-day-view *ngIf="date && (date.getMonth()===firstMonthDate.getMonth()&&date.getFullYear()===firstMonthDate.getFullYear() || shouldShowPrevNextDays())" [dayDirective]="getDayDirective(date)!" [date]="date"
         [thisMonth]="date.getMonth()===firstMonthDate.getMonth()&&date.getFullYear()===firstMonthDate.getFullYear()"
-        [isPrevNextMonth]="date.getMonth()!==firstMonthDate.getMonth()||date.getFullYear()!==firstMonthDate.getFullYear()">
+        [isPrevNextMonth]="shouldShowPrevNextDays() && (date.getMonth()!==firstMonthDate.getMonth()||date.getFullYear()!==firstMonthDate.getFullYear())">
     </app-day-view>
 </div>

--- a/projects/angular-datepicker2/src/lib/week-view/week-view.component.ts
+++ b/projects/angular-datepicker2/src/lib/week-view/week-view.component.ts
@@ -4,6 +4,7 @@ import { DayDirective } from "../day.directive";
 import { WeekService } from "../_service/week.service";
 import { DayViewComponent } from "../day-view/day-view.component";
 import { DateUtils } from "../_utils/date.utils";
+import { CalendarService } from "../_service/calendar.service";
 
 @Component({
   selector: "app-week-view",
@@ -18,7 +19,7 @@ export class WeekViewComponent implements OnInit {
   @Input() firstMonthDate!: Date;
   @Input() dayDirectives!: DayDirective[];
   dates: (Date | null)[] = [];
-  constructor(private weekService: WeekService) {}
+  constructor(private weekService: WeekService, private calendarService: CalendarService) {}
 
   ngOnInit() {
     this.dates = this.weekService.getWeek(this.date);
@@ -30,5 +31,10 @@ export class WeekViewComponent implements OnInit {
       (directive: DayDirective) => directive.date && DateUtils.isSameDay(directive.date, date)
     );
     return day;
+  }
+
+  shouldShowPrevNextDays(): boolean {
+    return this.calendarService.showPrevNextDaysInOneMonth && 
+           this.calendarService.getCountMonths() === 1;
   }
 }

--- a/projects/angular-datepicker2/src/lib/week-view/week-view.component.ts
+++ b/projects/angular-datepicker2/src/lib/week-view/week-view.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit, Input } from "@angular/core";
+import { Component, OnInit, Input, OnDestroy, ChangeDetectorRef } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { DayDirective } from "../day.directive";
 import { WeekService } from "../_service/week.service";
 import { DayViewComponent } from "../day-view/day-view.component";
 import { DateUtils } from "../_utils/date.utils";
 import { CalendarService } from "../_service/calendar.service";
+import { Subscription } from "rxjs";
 
 @Component({
   selector: "app-week-view",
@@ -14,15 +15,32 @@ import { CalendarService } from "../_service/calendar.service";
   styleUrls: ["./week-view.component.scss"],
   providers: [WeekService],
 })
-export class WeekViewComponent implements OnInit {
+export class WeekViewComponent implements OnInit, OnDestroy {
   @Input() date!: Date;
   @Input() firstMonthDate!: Date;
   @Input() dayDirectives!: DayDirective[];
   dates: (Date | null)[] = [];
-  constructor(private weekService: WeekService, private calendarService: CalendarService) {}
+  private subscriptions = new Subscription();
+  
+  constructor(
+    private weekService: WeekService, 
+    private calendarService: CalendarService,
+    private cdr: ChangeDetectorRef
+  ) {}
 
   ngOnInit() {
     this.dates = this.weekService.getWeek(this.date);
+    
+    // Subscribe to calendar updates to trigger change detection
+    this.subscriptions.add(
+      this.calendarService.updateDate.subscribe(() => {
+        this.cdr.detectChanges();
+      })
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
   }
 
   getDayDirective(date: Date | null): DayDirective | undefined {


### PR DESCRIPTION
Fixes logic for displaying previous/next month days, ensuring they only show in single-month view when `showPrevNextDaysInOneMonth` is enabled, and correctly applies opacity.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4f07c99-6d42-4fcf-8952-7e24b493c251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c4f07c99-6d42-4fcf-8952-7e24b493c251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

